### PR TITLE
Upated source timestamping to use 4-digit year format

### DIFF
--- a/CrvDatabase/DiCounters/DataVerificationTool.py
+++ b/CrvDatabase/DiCounters/DataVerificationTool.py
@@ -351,7 +351,7 @@ def sourceQA_local(inFilename = ""):
     plotThese = [] #List of serial numbers of dicounters that user wants to plotted from the file
     prevLen = 0
 
-    prodUpFilename = "sourceQA_VerifiedForUpload_" + strftime("%d%b%Y_%H:%M") + ".csv"
+    prodUpFilename = "sourceQA_VerifiedForUpload_" + strftime("%d%b%Y_%H%M") + ".csv"
     prodUploadFile = open(prodUpFilename,"w")
 
     ##If a filename is passed, try to open and read from it
@@ -426,7 +426,10 @@ def sourceQA_local(inFilename = ""):
             continue
 
         lnComponents = lines[lnNum].split(",")
-        sn = lnComponents[0].split("-")[1]
+        try: #########################
+            sn = lnComponents[0].split("-")[1]
+        except:
+            continue
         
         #Skip over any lines coresponding to dicounters not in specified list of sns to plot (if applicable)
         if len(plotThese) > 0:
@@ -492,7 +495,10 @@ def sourceQA_local(inFilename = ""):
 
         lnComponents = lines[lnNum].split(",")
 
-        sn = lnComponents[0].split("-")[1]
+        try: #########################
+            sn = lnComponents[0].split("-")[1]
+        except:
+            continue
 
         #Skip any dicounter that is not in list of sns to plot (if applicable)
         if len(plotThese) > 0:

--- a/CrvDatabase/DiCounters/SourceQA_FormatConverter.py
+++ b/CrvDatabase/DiCounters/SourceQA_FormatConverter.py
@@ -16,6 +16,7 @@
 ##08/08/18 - Added second try-catch block to repeat queries if failed in order to avoid connection based issues et al
 ##08/09/18 - Added code to remove newline character from the end of B-side channels when crystals were not present
 ##08/22/18 - Added default comment of "No Comment"
+##04/16/19 - Updated timestamp to use 4-digit year format
 
 ################################################################### Instructions ##################################################################################
 ##-This script can be run from and editor or terminal, the command line, or simply by double clicking on the file.                                               ##
@@ -224,7 +225,9 @@ def processData(comment = ""):
             if temp == -1:          ##Old file version which did not store temp
                 formattedLine += lnComponents[1] + ","
             else:                   ##File version which does have temp
-                formattedLine += lnComponents[2] + ","
+                timestamp = lnComponents[2].split(" ") #Make into 4 digit year format
+                formattedLine += timestamp[0][:-2] + "20" + timestamp[0][-2:] + " " + timestamp[1] + ","
+                #formattedLine += lnComponents[2] + ","
 
                 
             if len(lnComponents) >= 16: #If has crystal data

--- a/CrvDatabase/DiCounters/SourceQA_FormatConverter_NEW.py
+++ b/CrvDatabase/DiCounters/SourceQA_FormatConverter_NEW.py
@@ -18,6 +18,7 @@
 ##08/22/18 - Added default comment of "No Comment"
 ##09/24/18 - Added code to avoid duplicate timestamps by adding a "seconds" value to tests which have the same timestamp as the previous test
 ##           NOTE: This addition was forced due to improper labeling in data files - this code will no longer return correct source pos values if tests are not performed 1m from each side
+##04/16/19 - Updated timestamper to use 4-digit year format
 
 ################################################################### Instructions ##################################################################################
 ##-This script can be run from and editor or terminal, the command line, or simply by double clicking on the file.                                               ##
@@ -228,11 +229,15 @@ def processData(comment = ""):
                 formattedLine += lnComponents[1] + ","
             else:                   ##File version which does have temp
                 if lnComponents[2] == previousDT: #Appends a "seconds" value to a test which has the same timestamp as the previous test, avoiding duplicate timestamps
-                    formattedLine += lnComponents[2] + ":30,"
+                    timestamp = lnComponents[2].split(" ") #Make into 4 digit year format
+                    formattedLine += timestamp[0][:-2] + "20" + timestamp[0][-2:] + " " + timestamp[1] + ":30,"
+                    #formattedLine += lnComponents[2] + ":30,"
                     previousDT = lnComponents[2]
                 else:   
-                    formattedLine += lnComponents[2] + ","
-                    previousDT = lnComponents [2]
+                    timestamp = lnComponents[2].split(" ") #Make into 4 digit year format
+                    formattedLine += timestamp[0][:-2] + "20" + timestamp[0][-2:] + " " + timestamp[1] + ","
+                    ##formattedLine += lnComponents[2] + ","
+                    previousDT = lnComponents[2]
 
                 
             if len(lnComponents) >= 16: #If has crystal data


### PR DESCRIPTION
Intended to prevent having to reformat the dates of output files before uploading to the database